### PR TITLE
Fix duplicate imports in tool_search

### DIFF
--- a/WebSailor/src/tool_search.py
+++ b/WebSailor/src/tool_search.py
@@ -3,7 +3,6 @@ import json
 from concurrent.futures import ThreadPoolExecutor
 from typing import List, Union
 import requests
-from qwen_agent.tools.base import BaseTool, register_tool
 import os
 
 SEARCH_API_URL = os.getenv("SEARCH_API_URL")


### PR DESCRIPTION
## Summary
- remove duplicate import of `BaseTool` and `register_tool` from `tool_search.py`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688d59c12f30832fa1beac3741205338