### PR TITLE
Enable custom search endpoint

### DIFF
--- a/WebSailor/src/tool_search.py
+++ b/WebSailor/src/tool_search.py
@@ -28,7 +28,7 @@ class Search(BaseTool):
     }
 
     def google_search(self, query: str):
-        url = 'https://google.serper.dev/search'
+        url = SEARCH_API_URL or 'https://google.serper.dev/search'
         headers = {
             'X-API-KEY': GOOGLE_SEARCH_KEY,
             'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- allow overriding the default search endpoint in `tool_search`

## Testing
- `python -m py_compile WebSailor/src/tool_search.py`

------
https://chatgpt.com/codex/tasks/task_b_688d5c369f84832f82c5d717aa881091