### PR TITLE
Dockerize project and set default model path

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.env
+assets/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04
+
+# Çalışma dizini
+WORKDIR /app
+
+# Python ve temel bağımlılıkların kurulumu
+RUN apt-get update && apt-get install -y \
+    python3 python3-pip git curl build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Proje bağımlılıkları
+COPY WebSailor/requirements.txt WebSailor/requirements.txt
+RUN pip3 install --upgrade pip \
+    && pip3 install --no-cache-dir -r WebSailor/requirements.txt
+
+# Kodların kopyalanması
+COPY . .
+
+# Varsayılan model yolu
+ENV MODEL_PATH=/models
+RUN mkdir -p /models /app/output
+
+# Gerekli portlar
+EXPOSE 6001 6002
+
+CMD ["bash"]

--- a/README_TR.md
+++ b/README_TR.md
@@ -1,0 +1,51 @@
+# WebAgent Docker Kurulumu
+
+Bu proje, Tongyi Lab tarafından geliştirilen **WebAgent**'in Docker üzerinde GPU desteğiyle çalıştırılmasını sağlar.
+
+## Önkoşullar
+
+- NVIDIA GPU'lu bir makine.
+- Docker ve [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) kurulu olmalı.
+- WebSailor-3B model dosyalarının bulunduğu klasör (örnek: `D:/Mira/WebSailor-3B`).
+
+## Ortam Değişkenleri
+
+1. `.env.example` dosyasını `.env` olarak kopyalayın.
+2. Aşağıdaki anahtarları doldurun:
+   - `JINA_API_KEYS`, `GOOGLE_SEARCH_KEY`, `SEARCH_API_URL` gibi API bilgileri.
+   - `SUMMARY_MODEL_PATH`: Özetleme modeli için yol. Gerekirse bu modelin bulunduğu dizini de volume olarak bağlayın.
+
+## Docker İmajını Oluşturma
+
+```bash
+docker build -t webagent:latest .
+```
+
+## Konteyneri Çalıştırma
+
+Model dosyalarının bulunduğu dizini `/models` olarak bağlayın ve `.env` değerlerini içeri aktarın:
+
+```bash
+docker run --gpus all --rm \
+  --env-file .env \
+  -v D:/Mira/WebSailor-3B:/models \
+  webagent:latest \
+  bash WebSailor/src/run.sh sahibinden /app/output
+```
+
+- `sahibinden` yerine aşağıdaki veri setlerinden birini kullanabilirsiniz: `gaia`, `browsecomp_zh`, `browsecomp_en`, `xbench-deepsearch`, `sahibinden`.
+- Çıktıları host üzerinde görmek için ayrıca `-v $(pwd)/output:/app/output` parametresi ekleyebilirsiniz.
+
+Etkileşimli bir kabuk açmak için:
+
+```bash
+docker run --gpus all --rm \
+  --env-file .env \
+  -v D:/Mira/WebSailor-3B:/models \
+  -it webagent:latest bash
+```
+
+## Notlar
+
+- Varsayılan model yolu `/models` olarak tanımlıdır (`MODEL_PATH`). Farklı bir yol kullanmak isterseniz `-e MODEL_PATH=/farkli/yol` parametresi ekleyin.
+- `.env` dosyasını `--env-file` yerine volume olarak bağlamak isterseniz: `-v $(pwd)/.env:/app/.env`.

--- a/WebSailor/src/run.sh
+++ b/WebSailor/src/run.sh
@@ -1,4 +1,5 @@
 ##############Evaluation Parameters################
+# Usage: bash run.sh <dataset> <output_path>
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
@@ -8,7 +9,7 @@ if [ -f "$ROOT_DIR/.env" ]; then
     set +a
 fi
 
-export MODEL_PATH=$1 # Model path
+export MODEL_PATH=${MODEL_PATH:-/models} # Model path inside the container
 
 # Dataset names (strictly match the following names):
 # - gaia
@@ -16,8 +17,8 @@ export MODEL_PATH=$1 # Model path
 # - browsecomp_en (Full set, 1266 Cases)
 # - xbench-deepsearch
 # - sahibinden
-export DATASET=$2
-export OUTPUT_PATH=$3 # Output path for prediction results
+export DATASET=$1
+export OUTPUT_PATH=$2 # Output path for prediction results
 
 export TEMPERATURE=0.6 # LLM generation parameter, fixed at 0.6
 

--- a/WebSailor/src/scripts/test.sh
+++ b/WebSailor/src/scripts/test.sh
@@ -12,8 +12,8 @@ export MAX_LENGTH=$((1024 * 31 - 500))
 
 cd "$ROOT_DIR/WebSailor/src"
 
-# The arguments are the model path, the dataset name, and the location of the prediction file.
-# bash run.sh <model_path> <dataset> <output_path>
+# The arguments are the dataset name and the location of the prediction file.
+# bash run.sh <dataset> <output_path>
 
 # Dataset names (strictly match the following names):
 # - gaia
@@ -26,8 +26,8 @@ cd "$ROOT_DIR/WebSailor/src"
 # This folder must include:
 #   - model-00001-of-00002.safetensors
 #   - model-00002-of-00002.safetensors
-MODEL_PATH="D:/Mira/WebSailor-3B"
+export MODEL_PATH=${MODEL_PATH:-/models}
 
 # Run evaluation using the local model directory for the sahibinden dataset.
-bash run.sh "$MODEL_PATH" sahibinden output_path
+bash run.sh sahibinden output_path
 

--- a/setup.sh
+++ b/setup.sh
@@ -6,7 +6,7 @@ pip install -r WebSailor/requirements.txt
 
 # 2. (Varsa) Model dosyalarını kontrol et/yükle
 # Örnek: HuggingFace veya lokal model path ayarı
-# export MODEL_PATH="D:/Mira/WebSailor-3B/"
+# export MODEL_PATH="/models"
 # (model zaten indirildiyse bu adımı geçebilirsin)
 
 # 3. (Varsa) Ortam değişkenlerini ayarla


### PR DESCRIPTION
## Summary
- add Dockerfile for GPU-enabled deployment, defaulting model path to `/models`
- update run/test scripts to use `/models` and add Turkish README with build/run instructions
- add `.dockerignore` and reference model path in setup script comments

## Testing
- `bash -n WebSailor/src/run.sh`
- `bash -n WebSailor/src/scripts/test.sh`
- `bash -n setup.sh`
- `docker build -t webagent:latest .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_b_688e4ba24ea4832f90466d50c228c650