### PR TITLE
feat: load sahibinden credentials from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,8 @@ MAX_LLM_CALL_PER_RUN=40
 MAX_LENGTH=31244
 
 # --- Sahibinden.com credentials ---
-# These values are used by the authentication tool.
-SAHIBINDEN_EMAIL=murat.turan@deltaproje.com
-SAHIBINDEN_PASSWORD=y+y5dtnByh2S6+A
+# These values are used by the authentication tool.  Replace the placeholders
+# with your actual login information in your local .env file.
+SAHIBINDEN_EMAIL=your_email@example.com
+SAHIBINDEN_PASSWORD=your_password
 

--- a/WebSailor/src/tool_auth.py
+++ b/WebSailor/src/tool_auth.py
@@ -4,9 +4,11 @@ import undetected_chromedriver as uc
 import json
 import os
 import time
-from dotenv import load_dotenv
+from dotenv import load_dotenv, find_dotenv
 
 from tool_captcha import handle_captcha_ui, detect_captcha
+
+SESSION_FILE = os.path.join(os.path.dirname(__file__), "session_cookies.json")
 
 
 @register_tool("login", allow_overwrite=True)
@@ -18,10 +20,15 @@ class SahibindenAuth(BaseTool):
     # required for this tool.
     parameters = {"type": "object", "properties": {}, "required": []}
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        load_dotenv(find_dotenv())
+        self.username = os.getenv("SAHIBINDEN_EMAIL")
+        self.password = os.getenv("SAHIBINDEN_PASSWORD")
+
     def call(self, params: dict, **kwargs) -> str:
-        load_dotenv()
-        username = os.getenv("SAHIBINDEN_EMAIL")
-        password = os.getenv("SAHIBINDEN_PASSWORD")
+        username = self.username
+        password = self.password
 
         if not username or not password:
             return "giris basarisiz: kredensiyeller bulunamadi"
@@ -50,7 +57,7 @@ class SahibindenAuth(BaseTool):
                 time.sleep(3)
 
             cookies = driver.get_cookies()
-            with open("session_cookies.json", "w", encoding="utf-8") as f:
+            with open(SESSION_FILE, "w", encoding="utf-8") as f:
                 json.dump(cookies, f, ensure_ascii=False)
             return json.dumps(cookies, ensure_ascii=False)
         except Exception as e:

--- a/WebSailor/src/tool_search.py
+++ b/WebSailor/src/tool_search.py
@@ -1,16 +1,18 @@
 from qwen_agent.tools.base import BaseTool, register_tool
 import json
 import os
-from typing import List, Union
+from typing import Union
 import requests
 from urllib.parse import quote_plus
 from bs4 import BeautifulSoup
 import time
 import undetected_chromedriver as uc
-from dotenv import load_dotenv
+from dotenv import load_dotenv, find_dotenv
 
 from tool_auth import SahibindenAuth
 from tool_captcha import handle_captcha_ui, detect_captcha
+
+SESSION_FILE = os.path.join(os.path.dirname(__file__), "session_cookies.json")
 
 
 
@@ -34,7 +36,7 @@ class Search(BaseTool):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        load_dotenv()
+        load_dotenv(find_dotenv())
         self.session = requests.Session()
         self.session.headers.update(
             {
@@ -52,9 +54,9 @@ class Search(BaseTool):
 
     def _load_cookies(self, refresh: bool = False) -> None:
         cookies = None
-        if not refresh and os.path.exists("session_cookies.json"):
+        if not refresh and os.path.exists(SESSION_FILE):
             try:
-                with open("session_cookies.json", "r", encoding="utf-8") as f:
+                with open(SESSION_FILE, "r", encoding="utf-8") as f:
                     cookies = json.load(f)
             except Exception:
                 cookies = None


### PR DESCRIPTION
## Summary
- replace hard-coded Sahibinden credentials in `.env.example` with placeholders
- load credentials from `.env` in `SahibindenAuth` and persist cookies to a stable file
- initialize search tool with same cookie file for authenticated requests

## Testing
- `python -m py_compile WebSailor/src/tool_auth.py WebSailor/src/tool_search.py`
- `python - <<'PY'
import sys, os
sys.path.append('WebSailor/src')
from tool_auth import SahibindenAuth
print(SahibindenAuth().call({})[:200])
PY` *(fails: URLError: Tunnel connection failed: 403 Forbidden)*
- `python - <<'PY'
import sys
sys.path.append('WebSailor/src')
from tool_search import Search
print(Search().call({"query": "test"})[:200])
PY` *(fails: URLError: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_688fe71958d0832fac771ced168117ca