### PR TITLE
Fix login selectors and category navigation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,9 +20,8 @@ MAX_LLM_CALL_PER_RUN=40
 # Maximum token length allowed for the LLM context.
 MAX_LENGTH=31244
 
-# --- Sahibinden.com credentials ---
-# These values are used by the authentication tool.  Replace the placeholders
-# with your actual login information in your local .env file.
-SAHIBINDEN_EMAIL=your_email@example.com
-SAHIBINDEN_PASSWORD=your_password
+# SAHIBINDEN.COM LOGIN CREDENTIALS
+SAHIBINDEN_EMAIL=murat.turan@deltaproje.com
+SAHIBINDEN_PASSWORD=y+y5dtnByh2S6+A
+SAHIBINDEN_BASE_URL=https://www.sahibinden.com
 

--- a/WebSailor/core/workflow_manager.py
+++ b/WebSailor/core/workflow_manager.py
@@ -1,0 +1,38 @@
+from tool_search import Search as ToolSearch
+
+
+class WorkflowManager:
+    def __init__(self, page=None):
+        self.page = page
+
+    def parse_real_estate_query(self, query):
+        return {
+            "category_path": [],
+            "keywords": query.split() if isinstance(query, str) else query,
+        }
+
+    async def process_search_request(self, query):
+        try:
+            parsed = self.parse_real_estate_query(query)
+
+            search_tool = ToolSearch()
+            nav_success, nav_msg = await search_tool.navigate_to_category(
+                self.page, parsed["category_path"]
+            )
+
+            if not nav_success:
+                return {"error": nav_msg}
+
+            results = await search_tool.search_with_filters(self.page, parsed)
+            return results
+
+        except Exception as e:
+            return {"error": f"Workflow failed: {e}"}
+
+    async def handle_login_redirect(self, page):
+        """Handle redirect from Bana Özel back to main page"""
+        current_url = page.url
+        if "banaozel" in current_url:
+            await page.click('a[href="https://www.sahibinden.com"] img, .logo')
+            await page.wait_for_load_state('networkidle')
+

--- a/WebSailor/src/tool_auth.py
+++ b/WebSailor/src/tool_auth.py
@@ -37,22 +37,33 @@ class SahibindenAuth(BaseTool):
         options.headless = True
         driver = uc.Chrome(options=options)
         try:
-            driver.get("https://www.sahibinden.com/giris")
+            login_url = f"{os.getenv('SAHIBINDEN_BASE_URL', 'https://www.sahibinden.com')}/giris"
+            driver.get(login_url)
             time.sleep(2)
-            driver.find_element(By.ID, "username").send_keys(username)
-            driver.find_element(By.ID, "password").send_keys(password)
-            driver.find_element(By.ID, "password").submit()
+
+            email_selector = 'input[type="email"], input[placeholder*="posta"], #email'
+            password_selector = 'input[type="password"], #password'
+            login_button_xpath = (
+                "//button[contains(text(), 'E-posta ile giriş yap')] | "
+                "//input[contains(@value, 'giriş')]"
+            )
+
+            driver.find_element(By.CSS_SELECTOR, email_selector).send_keys(username)
+            driver.find_element(By.CSS_SELECTOR, password_selector).send_keys(password)
+            time.sleep(2)
+            driver.find_element(By.XPATH, login_button_xpath).click()
             time.sleep(3)
 
             if detect_captcha(driver):
                 driver.quit()
                 options.headless = False
                 driver = uc.Chrome(options=options)
-                driver.get("https://www.sahibinden.com/giris")
+                driver.get(login_url)
                 time.sleep(2)
-                driver.find_element(By.ID, "username").send_keys(username)
-                driver.find_element(By.ID, "password").send_keys(password)
-                driver.find_element(By.ID, "password").submit()
+                driver.find_element(By.CSS_SELECTOR, email_selector).send_keys(username)
+                driver.find_element(By.CSS_SELECTOR, password_selector).send_keys(password)
+                time.sleep(2)
+                driver.find_element(By.XPATH, login_button_xpath).click()
                 handle_captcha_ui(driver, driver.current_url)
                 time.sleep(3)
 

--- a/WebSailor/src/tool_search.py
+++ b/WebSailor/src/tool_search.py
@@ -126,6 +126,35 @@ class Search(BaseTool):
         finally:
             driver.quit()
 
+    async def navigate_to_category(self, page, category_path):
+        try:
+            await page.goto("https://www.sahibinden.com")
+            await page.wait_for_load_state('networkidle')
+
+            category_map = {
+                'emlak': 'a:has-text("Emlak")',
+                'konut': 'a:has-text("Konut")',
+                'is_yeri': 'a:has-text("İş Yeri")',
+                'arsa': 'a:has-text("Arsa")',
+                'vasita': 'a:has-text("Vasıta")',
+                'otomobil': 'a:has-text("Otomobil")'
+            }
+
+            for category in category_path:
+                if category.lower() in category_map:
+                    selector = category_map[category.lower()]
+                    await page.click(selector)
+                    await page.wait_for_load_state('networkidle')
+
+            return True, "Navigation successful"
+
+        except Exception as e:
+            return False, f"Navigation failed: {e}"
+
+    async def search_with_filters(self, page, parsed):
+        query = " ".join(parsed.get('keywords', [])) if isinstance(parsed.get('keywords'), list) else parsed.get('keywords', '')
+        return self._search_once(query)
+
     def call(self, params: Union[str, dict], **kwargs) -> str:
         try:
             query = params["query"]


### PR DESCRIPTION
## Summary
- update sample env with Sahibi̇nden login credentials and base URL
- correct login element selectors and integrate base URL in auth tool
- add category navigation and filter search helpers with workflow manager stub

## Testing
- `python test_auth.py` *(fails: No such file or directory)*
- `python test_categories.py` *(fails: No such file or directory)*
- `python main.py "Kadıköy'de 2+1 kiralık daire"` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_688fee49cd68832fb5772230084c9063